### PR TITLE
chore: add Clarkson mirror back to the list

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rebornos-mirrorlist
-pkgver=20240502
+pkgver=20240511
 pkgrel=1
 pkgdesc="RebornOS mirror list for use by pacman"
 arch=('any')
@@ -7,7 +7,7 @@ url="https://github.com/RebornOS-Team/rebornos-mirrorlist"
 license=('GPL3')
 source=("reborn-mirrorlist")
 backup=("etc/pacman.d/reborn-mirrorlist")
-sha256sums=('910064564a196977428f01d979ea7e686066e5bd5856bf0e5b4bf8ce11c8e81d')
+sha256sums=('7629f85ebc53a2ff1959b0120b7722c002db24db3328bd6ea0e1b577e5cabed0')
 
 pkgver() {
   date +%Y%m%d

--- a/gen-mirrors-json.sh
+++ b/gen-mirrors-json.sh
@@ -16,9 +16,11 @@ revision=$(echo "$metadata_line" | cut -d'-' -f2)
 
 # Start JSON structure
 echo "{" >"$json_file"
-echo "  \"date\": $date," >>"$json_file"
-echo "  \"revision\": $revision," >>"$json_file"
-echo "  \"mirrors\": [" >>"$json_file"
+{
+  echo "  \"date\": $date,"
+  echo "  \"revision\": $revision,"
+  echo "  \"mirrors\": ["
+} >>"$json_file"
 
 # Read each line from the mirrorlist file
 while IFS= read -r line; do

--- a/mirrorlist.json
+++ b/mirrorlist.json
@@ -1,5 +1,5 @@
 {
-  "date": 20240502,
+  "date": 20240511,
   "revision": 1,
   "mirrors": [
     {
@@ -21,6 +21,11 @@
       "name": "FreeDif SG Mirror",
       "location": "Singapore, SEA",
       "server": "https://mirror.freedif.org/rebornos/RebornOS/"
+    },
+    {
+      "name": "Clarkson US Mirror",
+      "location": "New York, US East",
+      "server": "https://mirror.clarkson.edu/RebornOS/RebornOS/"
     },
     {
       "name": "SourceForge Mirror",

--- a/reborn-mirrorlist
+++ b/reborn-mirrorlist
@@ -1,4 +1,4 @@
-# --> RebornOS Mirrorlist from 20240502-1 <-- #
+# --> RebornOS Mirrorlist from 20240511-1 <-- #
 
 # Name: RebornOS Main Mirror
 # Location: Global
@@ -15,6 +15,10 @@ Server = https://sea-usw-lb.soulharsh007.dev/RebornOS/
 # Name: FreeDif SG Mirror
 # Location: Singapore, SEA
 Server = https://mirror.freedif.org/rebornos/RebornOS/
+
+# Name: Clarkson US Mirror
+# Location: New York, US East
+Server = https://mirror.clarkson.edu/RebornOS/RebornOS/
 
 # Name: SourceForge Mirror
 # Location: Global

--- a/retired-mirrors
+++ b/retired-mirrors
@@ -137,10 +137,6 @@ Server = https://apac-us-mirror.soulharsh007.rocks/RebornOS/
 # Mirrors with Mirror with old versions #
 #########################################
 
-# Name: Clarkson US Mirror
-# Location: New York, US East
-Server = https://mirror.clarkson.edu/RebornOS/RebornOS/
-
 ########################
 # Mirrors with errors: #
 ########################


### PR DESCRIPTION
chore: add Clarkson mirror back to the list

fix ShellCheck `SC2129` in `gen-mirrors-json.sh`